### PR TITLE
Support any frame format

### DIFF
--- a/libuvc/src/main/jni/UVCCamera/JniUVCCamera.cpp
+++ b/libuvc/src/main/jni/UVCCamera/JniUVCCamera.cpp
@@ -2243,7 +2243,6 @@ Java_com_jiangdg_uvc_UVCCamera_nativeSetPreviewSize(JNIEnv *env,
         return camera->getPreview()->setPreviewSize(width,
                                                     height,
                                                     (uint16_t)fps,
-                                                    mode,
                                                     bandwidth);
     }
     return JNI_ERR;

--- a/libuvc/src/main/jni/UVCCamera/UVCPreviewBase.h
+++ b/libuvc/src/main/jni/UVCCamera/UVCPreviewBase.h
@@ -38,7 +38,6 @@
 #define DEFAULT_PREVIEW_HEIGHT 480
 #define DEFAULT_PREVIEW_FPS_MIN 1
 #define DEFAULT_PREVIEW_FPS_MAX 30
-#define DEFAULT_PREVIEW_MODE 0
 #define DEFAULT_BANDWIDTH 1.0f
 #define PREVIEW_PIXEL_BYTES 4    // RGBA/RGBX
 
@@ -98,12 +97,10 @@ protected:
     uvc_device_handle_t *mDeviceHandle;
     volatile bool mIsRunning;
 
-    int requestWidth, requestHeight, requestMode;
+    int requestWidth, requestHeight;
     uint16_t requestFps;
 
     uint16_t frameWidth, frameHeight;
-    int frameMode;
-    size_t frameBytes;
     pthread_mutex_t preview_mutex;
     pthread_cond_t preview_sync;
     std::list<UvcPreviewFrame> mPreviewFrames;
@@ -150,7 +147,6 @@ public:
      */
     int setPreviewSize(int width, int height,
                        int fps,
-                       int mode,
                        float bandwidth = 1.0f);
 
     int startPreview();

--- a/libuvc/src/main/jni/UVCCamera/UVCPreviewJni.cpp
+++ b/libuvc/src/main/jni/UVCCamera/UVCPreviewJni.cpp
@@ -197,28 +197,13 @@ void UVCPreviewJni::clearDisplay() {
 void UVCPreviewJni::handleFrame(uint16_t deviceId,
                                 const UvcPreviewFrame &frame) {
     uvc_error_t result;
-    if (frameMode) {
-        // MJPEG mode
-        if (LIKELY(frame.mFrame)) {
-            // TODO remove double convert MJPEG->YUYV->RGB
-//            LOGE("uvc_mjpeg2yuyv++ %llu", frame.mTimestamp.time_since_epoch().count());
-            auto rgbFrame = uvc_allocate_frame(frame.mFrame->width * frame.mFrame->height * 3);
-            result = uvc_mjpeg2rgb(frame.mFrame, rgbFrame);   // MJPEG => rgb
-//            LOGE("uvc_mjpeg2yuyv-- %llu", frame.mTimestamp.time_since_epoch().count());
-            if (LIKELY(!result)) {
-                draw_preview_rgb(rgbFrame);
-            }
-            uvc_free_frame(rgbFrame);
+    if (LIKELY(frame.mFrame)) {
+        auto rgbFrame = uvc_allocate_frame(frame.mFrame->width * frame.mFrame->height * 3);
+        result = uvc_any2rgb(frame.mFrame, rgbFrame);
+        if (LIKELY(!result)) {
+            draw_preview_rgb(rgbFrame);
         }
-    } else {
-        // yuvyv
-        // TODO not implemented
-//        uvc_frame_t rgbxFrame = get_frame(frame.mFrame->width * frame.mFrame->height * 4);
-//        result = uvc_yuyv2rgb(frame.mFrame, rgbxFrame); // yuyv => rgbx
-//        if (LIKELY(!result)) {
-//            draw_preview_rgb(rgbxFrame);
-//        }
-//        recycle_frame(rgbxFrame);
+        uvc_free_frame(rgbFrame);
     }
 }
 


### PR DESCRIPTION
These changes allow to support all frame formats exposed by libuvc. We need those to make the demo application work with a camera that doesn't support the `MJPEG` and `YUYV` frame formats.

First, we can use the libuvc `uvc_any2rgb()` function to convert frames into RGB for preview. This function relies on the format data contained in the frames and this allows to simplify the render code while getting support for all formats.

Then, we can set `UVC_FRAME_FORMAT_ANY` when configuring the preview, so libuvc choses a supported frame format from the camera.

With these changes, I had my camera work in the demo application. Also I tested that a camera that already worked still works.

Now, the application Kotlin code itself could be simplified by also removing the format handling logic (which is no-op with these changes). I started to do it locally, but maybe it is better to do this in a separate step, when/if these changes are merged here.